### PR TITLE
Update algorithm to process 8 bytes at a time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,14 @@ name: CI
 
 on:
   push:
-    branches: main
-    tags: v*
+    branches: [main]
+    tags: ["v*"]
   pull_request:
-    branches: "*"
+    branches: ["*"]
 
 jobs:
-  all:
-    name: all
+  push:
+    name: push
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ The following functions are exported from this package:
 
 ```ts
 function crc32Init(): number;
-function crc32Update(prev: number, data: Uint8Array): number;
+function crc32Update(prev: number, data: ArrayBufferView): number;
 function crc32Final(prev: number): number;
 
-function crc32(data: Uint8Array): number;
+function crc32(data: ArrayBufferView): number;
 ```
 
 Note: Since the CRC algorithm works with unsigned data, the `crc32` and `crc32Final` functions always return **non-negative** numbers. For example, CRC32(0x01) returns 2768625435 rather than -1526341861.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,20 +1,25 @@
 import { crc32, crc32Final, crc32Init, crc32Update } from "./index";
 
 describe("crc32", () => {
-  /**
-   * Generated using zlib in Python:
-   *
-   *     [hex(zlib.crc32(bytes.fromhex(('0123456789abcdef'*3)[:2*i]))) for i in range(8*3+1)]
-   */
-  it.each(
-    [
+  it("returns correct results for any alignment", () => {
+    // Generated using zlib via Python:
+    // [hex(zlib.crc32(bytes.fromhex(('0123456789abcdef'*3)[:2*i]))) for i in range(8*3+1)]
+    const expected = [
       0x0, 0xa505df1b, 0xfaa552cc, 0x469c715b, 0xfd2b0f7b, 0x814c57b2, 0xb6e80b1a, 0xca0340f1,
       0x28c7d1ae, 0x94439625, 0x3bf5092e, 0x859a254, 0x6ddad739, 0x190e86d6, 0xfcafec8a, 0x3a469452,
       0x67e86628, 0x90d79f87, 0x3295fe3, 0xedb4c00f, 0x9186b227, 0xe3fde7d0, 0x1536bade, 0x56a998e9,
       0x3b37e320,
-    ].map((crc, i) => [crc, "0123456789abcdef".repeat(3).slice(0, 2 * i)] as [number, string]),
-  )("returns %s when given %s", (expected, hex) => {
-    expect(crc32(Buffer.from(hex, "hex"))).toBe(expected);
+    ];
+    expected.forEach((crc, length) => {
+      const hex = "0123456789abcdef".repeat(3).slice(0, 2 * length);
+      for (let offset = 0; offset < 64; offset++) {
+        // Using Buffer.alloc instead of Buffer.from ensures the buffer is newly allocated so its
+        // initial byteOffset will be 0.
+        const data = Buffer.alloc(offset + length, "fe".repeat(offset) + hex, "hex");
+        expect(data.byteOffset).toBe(0);
+        expect(crc32(new Uint8Array(data.buffer, offset, length))).toBe(crc);
+      }
+    });
   });
 
   it("returns correct result for incremental updates", () => {


### PR DESCRIPTION
This algorithm is adapted from: https://github.com/komrad36/CRC#option-9-8-byte-tabular

The 8-byte variant is chosen somewhat arbitrarily as the default implementation rather than the 16-byte variant, because the memory requirement is less and both variants have reasonable performance. (Unclear why there is a small difference in the main exported implementation and the other 8-byte implementation in benchmarks. :shrug:)

Adds tests to ensure the results are the same as the naïve implementation regardless of data length and alignment.

Results from my M1 MacBook Air (16GB RAM):

```
$ node --version
v15.14.0
$ yarn bench
yarn run v1.22.10
$ ts-node --project tsconfig.cjs.json bench/index.ts
Validating CRC implementations:
┌─────────┬────────────┬────────────┬────────────┬────────────┬────────────┬────────────┬────────────┐
│ (index) │  current   │   naive    │   1 byte   │   2 byte   │   4 byte   │   8 byte   │  16 byte   │
├─────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤
│    0    │ 1545002771 │ 1545002771 │ 1545002771 │ 1545002771 │ 1545002771 │ 1545002771 │ 1545002771 │
└─────────┴────────────┴────────────┴────────────┴────────────┴────────────┴────────────┴────────────┘
Results match.
Running "Table generation" suite...
Progress: 100%

  ternary:
    387 704 ops/s, ±0.77%   | slowest, 51.59% slower

  branchless:
    565 049 ops/s, ±0.95%   | 29.44% slower

  branchless unrolled:
    800 850 ops/s, ±0.57%   | fastest

Finished 3 cases!
  Fastest: branchless unrolled
  Slowest: ternary
Running "CRC" suite...
Progress: 100%

  naive:
    16 ops/s, ±0.31%      | slowest, 99.38% slower

  1 byte:
    352 ops/s, ±0.27%     | 86.34% slower

  2 bytes:
    560 ops/s, ±0.31%     | 78.26% slower

  4 bytes:
    1 053 ops/s, ±0.43%   | 59.12% slower

  8 bytes:
    1 785 ops/s, ±7.34%   | 30.71% slower

  16 bytes:
    2 576 ops/s, ±0.36%   | fastest

  current implementation:
    2 017 ops/s, ±0.43%   | 21.7% slower

  current implementation, unaligned:
    2 016 ops/s, ±0.40%   | 21.74% slower

Finished 8 cases!
  Fastest: 16 bytes
  Slowest: naive
✨  Done in 67.45s.
```