### PR TITLE
Demote Dependabot to weekly schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
Dependabot is pretty noisy and rarely/never actually urgent. We do want to stay up to date, but daily updates are a distraction.