### PR TITLE
Bump to 1.0.0, publish with provenance attestation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,12 @@ jobs:
       - run: yarn pack
       - name: Publish to NPM (dry run)
         # `yarn publish` does not support --provenance
-        run: npm publish --provenance --access public --dry-run
+        run: npm publish foxglove-crc-*.tgz --provenance --access public --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
       - name: Publish to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         # `yarn publish` does not support --provenance
-        run: npm publish --provenance --access public
+        run: npm publish foxglove-crc-*.tgz --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ jobs:
     name: push
     runs-on: ubuntu-latest
 
+    permissions:
+      # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
+      id-token: write
+
     steps:
       - uses: actions/checkout@v2
 
@@ -27,8 +31,15 @@ jobs:
       - run: yarn run lint:ci
       - run: yarn run test
 
+      - run: yarn pack
+      - name: Publish to NPM (dry run)
+        # `yarn publish` does not support --provenance
+        run: npm publish --provenance --access public --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
       - name: Publish to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: yarn publish --access public
+        # `yarn publish` does not support --provenance
+        run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 *.log
+*.tgz
 *.tsbuildinfo
 dist/
 node_modules/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 // -*- jsonc -*-
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.detectIndentation": false,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Fast CRC32 computation in TypeScript
 
-[![npm version](https://img.shields.io/npm/v/@foxglove/crc)](https://www.npmjs.com/package/@foxglove/crc)
+[![npm version](https://img.shields.io/npm/v/@foxglove/crc)](https://www.npmjs.com/package/@foxglove/crc) ![](https://img.shields.io/badge/dependencies-0-green)
 
 ## Introduction
 
@@ -48,25 +48,25 @@ crc = crc32Final(crc);
 
 This package achieves a >5x performance improvement over many other CRC packages, because of the multi-byte algorithms used (adapted from https://github.com/komrad36/CRC).
 
-The following benchmarks were recorded on a M1 MacBook Air with 16GB of RAM. Each iteration ("op") is processing 1MB of data.
+The following benchmarks were recorded on a MacBook Pro with an M1 Pro chip and 16GB of RAM. Each iteration ("op") is processing 1MB of data.
 
 ```
 $ yarn bench
 ...
   crc:
-    354.5 ops/s, ±0.48%   | 82.27% slower
+    355 ops/s, ±0.56%     | 81.52% slower
 
   node-crc:
-    315.8 ops/s, ±0.48%   | slowest, 84.21% slower
+    376 ops/s, ±0.14%     | 80.43% slower
 
   crc-32:
-    354.3 ops/s, ±0.39%   | 82.28% slower
+    1 057 ops/s, ±0.16%   | 44.98% slower
 
   polycrc:
-    316.1 ops/s, ±0.35%   | 84.19% slower
+    327 ops/s, ±0.21%     | slowest, 82.98% slower
 
   this package:
-    2 000 ops/s, ±0.41%   | fastest
+    1 921 ops/s, ±0.18%   | fastest
 ```
 
 ## References

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@foxglove/crc",
   "private": false,
-  "version": "0.0.3",
+  "version": "1.0.0",
   "description": "Fast CRC32 computation in TypeScript",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
### Changelog
No changes, just bumping the version number to reflect stability.

### Description

- Bump version to 1.0.0
- Publish to NPM with [provenance attestation](https://github.blog/2023-04-19-introducing-npm-package-provenance/)
- Update readme