### PR TITLE
Bump to node 20 for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 20.x
           registry-url: https://registry.npmjs.org
           cache: yarn
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ jobs:
       - run: yarn run lint:ci
       - run: yarn run test
 
+      - name: Unpublish 1.0.0
+        run: npm unpublish @foxglove/crc@1.0.0
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
       - run: yarn pack
       - name: Publish to NPM (dry run)
         # `yarn publish` does not support --provenance

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,6 @@ jobs:
       - run: yarn run lint:ci
       - run: yarn run test
 
-      - name: Unpublish 1.0.0
-        run: npm unpublish @foxglove/crc@1.0.0
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
       - run: yarn pack
       - name: Publish to NPM (dry run)
         # `yarn publish` does not support --provenance

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@foxglove/crc",
   "private": false,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Fast CRC32 computation in TypeScript",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
### Changelog
None

### Description

I believe publishing with provenance didn't work because of an outdated npm version